### PR TITLE
Implement continuous monitoring with Ollama integration

### DIFF
--- a/Core/llm_client.py
+++ b/Core/llm_client.py
@@ -1,0 +1,65 @@
+import json
+import re
+import shlex
+import subprocess
+from typing import List
+
+import requests
+
+from .output_manager import OutputManager
+
+
+def check_internet(url: str) -> bool:
+    """Return True if the specified URL is reachable."""
+    try:
+        requests.get(url, timeout=5)
+        return True
+    except requests.RequestException:
+        return False
+
+
+def send_scan_results(scan_results: dict, llm_ip: str) -> str:
+    """Send scan results to the Ollama server and return the response text."""
+    url = f"http://{llm_ip}/api/generate"
+    payload = {
+        "model": "llama3",
+        "prompt": "Analyze these scan results and suggest next commands to run:\n"
+        + json.dumps(scan_results, indent=2),
+        "stream": False,
+    }
+    response = requests.post(url, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("response", "")
+
+
+def extract_commands(text: str) -> List[str]:
+    """Extract shell commands from the LLM response text."""
+    commands: List[str] = []
+    code_blocks = re.findall(r"```(?:bash|sh)?\n(.*?)```", text, re.DOTALL)
+    for block in code_blocks:
+        for line in block.strip().splitlines():
+            line = line.strip()
+            if line and not line.startswith("#"):
+                commands.append(line)
+    for line in text.splitlines():
+        line = line.strip()
+        if line.startswith("$ "):
+            commands.append(line[2:])
+    return commands
+
+
+def execute_commands(commands: List[str], output_manager: OutputManager) -> None:
+    """Execute a list of commands securely without using the shell."""
+    for cmd in commands:
+        output_manager.print_info("Executing", cmd)
+        try:
+            result = subprocess.run(
+                shlex.split(cmd), capture_output=True, text=True, check=True
+            )
+            if result.stdout:
+                output_manager.print_info("Output", result.stdout.strip())
+            if result.stderr:
+                output_manager.print_warning(result.stderr.strip())
+        except subprocess.CalledProcessError as e:
+            output_manager.print_error(f"Command '{cmd}' failed: {e}")

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ python mirkat.py -p <project_code> -c <client_name> -s <scope> [-l <llm_ip>]
 python mirkat.py -p PROJ123 -c "Client Name" -s "192.168.1.1, 192.168.1.2" -l "127.0.0.1:11434"
 ```
 
+### Continuous Monitoring
+
+Use `monitor.py` for unattended monitoring. It runs scans at a defined interval and can communicate with an Ollama server if available.
+
+```sh
+python monitor.py -s <scope> [-c <client_name>] [-p <project_prefix>] [-l <llm_ip>] [-i <interval_seconds>]
+```
+
+To start monitoring automatically on boot (e.g., on a Raspberry Pi), create a systemd service or an `@reboot` cron entry that launches the above command.
+
 ## Project Structure
 
 Mirkat organizes output and reports into a structured directory format:

--- a/monitor.py
+++ b/monitor.py
@@ -1,0 +1,45 @@
+import argparse
+import time
+from datetime import datetime
+
+from mirkat import Mirkat
+from Core import config
+from Core.llm_client import send_scan_results, extract_commands, execute_commands, check_internet
+from Core.utils import setup_logging
+
+
+def run_scan(project_code: str, client_name: str, scope: str, llm_ip: str | None):
+    m = Mirkat(project_code=project_code, client_name=client_name, scope=scope, llm_ip=llm_ip)
+    m.setup_project_directory(config.PROJECT_DIR)
+    results = m.execute_scans()
+    m.generate_reports(results)
+    if llm_ip and check_internet(f"http://{llm_ip}"):
+        try:
+            response = send_scan_results(results, llm_ip)
+            commands = extract_commands(response)
+            if commands:
+                execute_commands(commands, m.output_manager)
+        except Exception as e:
+            m.output_manager.print_error(f"LLM interaction failed: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Continuous network monitoring")
+    parser.add_argument("-s", "--scope", required=True, help="Targets to scan")
+    parser.add_argument("-c", "--client_name", default="AutoClient", help="Client name")
+    parser.add_argument("-p", "--project_prefix", default="AUTO", help="Project code prefix")
+    parser.add_argument("-l", "--llm", required=False, help="Ollama server IP")
+    parser.add_argument("-i", "--interval", type=int, default=3600, help="Seconds between scans")
+    args = parser.parse_args()
+
+    setup_logging("monitor.log")
+
+    while True:
+        timestamp = datetime.utcnow().strftime("%Y%m%d%H%M%S")
+        project_code = f"{args.project_prefix}_{timestamp}"
+        run_scan(project_code, args.client_name, args.scope, args.llm)
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 openpyxl
+requests


### PR DESCRIPTION
## Summary
- add `llm_client` module for talking to an Ollama server
- integrate LLM summarization into `mirkat`
- add `monitor.py` for continuous scanning
- document hands-off monitoring in the README
- update requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c019d998c832bbf072c75d3e20e1d